### PR TITLE
Minor typo in links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 /log/*.log
 /tmp
 .DS_Store
+.redcar
+/.redcar

--- a/app/views/pages/landing.html.slim
+++ b/app/views/pages/landing.html.slim
@@ -21,7 +21,7 @@
       h2 CRB Labs
 
       markdown:
-        CRB Labs' goal is to develop and release great [Open Source software][1] while also teaching core [Ruby][1] and [Rails][2] concepts to class participants. By helping us develop our software, contributors gain:
+        CRB Labs' goal is to develop and release great [Open Source software][1] while also teaching core [Ruby][2] and [Rails][3] concepts to class participants. By helping us develop our software, contributors gain:
 
         * Ruby and Rails experience
         * Another line item on your resume


### PR DESCRIPTION
The CRB Labs section of the page links both "Open source software" and "Ruby" to the Wikipedia page for OSS, and "Rails" to the Ruby page.
