### PR TITLE
Logo fix

### DIFF
--- a/app/assets/stylesheets/screen.sass
+++ b/app/assets/stylesheets/screen.sass
@@ -114,7 +114,8 @@ ul#speakers
   text-align: center
 
   img
-    height: 80px
+    max-height: 80px
+    max-width: 80%
     margin: 1em
     background: whitesmoke
     padding: 1em


### PR DESCRIPTION
This prevents the O'Reilly logo from flowing past the edge of the screen on small screens.

Before:
![screen shot 2015-06-15 at 7 40 38 pm](https://cloud.githubusercontent.com/assets/2058614/8173079/7eece00a-1396-11e5-98c3-cf659c968431.png)

After:
![screen shot 2015-06-15 at 7 40 06 pm](https://cloud.githubusercontent.com/assets/2058614/8173080/832cc658-1396-11e5-8db5-96e75c68032f.png)