### PR TITLE
Added ready made rc as a ruby company

### DIFF
--- a/public/companies.yml
+++ b/public/companies.yml
@@ -25,3 +25,11 @@
   location: Downtown Columbus
   team_size: Small
   other_tech: Javascript, Backbone, iOS, Android
+
+- name: Ready Made RC, LLC 
+  url: https://www.readymaderc.com
+  market: Online Retail 
+  location: Lewis Center
+  team_size: Small 
+  other_tech: React, PHP
+


### PR DESCRIPTION
My company's codebase is getting closer to being 90% Ruby, I wanted to get them list on CRB's homepage. 