### PR TITLE
Fixes Bold Penguin URL

### DIFF
--- a/public/companies.yml
+++ b/public/companies.yml
@@ -13,7 +13,7 @@
   other_tech: Javascript, iOS
 
 - name: Bold Penguin
-  url: https://www.boldpenguin.com
+  url: http://www.boldpenguin.com
   market: Insurtech
   location: Downtown Columbus
   team_size: Small


### PR DESCRIPTION
Apparently we don't use `https` for our website. 🤦‍♀️ 

Sorry for the redundancy! Thank you very much for adding us.