### PR TITLE
fix for #60 and image update

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@ Speaker.delete_all
 BoardMember.delete_all
 Video.delete_all
 
-Meeting.insert_times_for_five_years
+Meeting.find_or_create_next_date
 
 20.times do
   Video.create do |v|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       ADMIN_PASSWORD: admin
 
   postgres:
-    image: postgres:9.6
+    image: postgres:10
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password


### PR DESCRIPTION
This fixes the issue where the insert_times_for_five_years method was no longer available. Updated to use the new method for populating dates. 