### PR TITLE
Add Test Double to companies

### DIFF
--- a/public/companies.yml
+++ b/public/companies.yml
@@ -11,6 +11,13 @@
   location: Downtown Columbus
   team_size: Small
   other_tech: Javascript, iOS
+  
+- name: Test Double
+  url: https://testdouble.com/
+  market: Consulting
+  location: Your Home
+  team_size: Small
+  other_tech: Javascript, Elixir
 
 - name: Bold Penguin
   url: http://www.boldpenguin.com


### PR DESCRIPTION
Test Double was listed as a sponsor but not a Ruby Columbus company.