### PR TITLE
WIP: Add Talk Submission Form

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -38,6 +38,7 @@ html
           = link_to "GitHub", "https://github.com/columbusrb"
           = link_to "Mailing List", "http://eepurl.com/cVggdb"
           = link_to "Twitter", "https://twitter.com/columbusrb"
+          = link_to "Submit Talk", "https://docs.google.com/forms/d/e/1FAIpQLSfVTxPvX6kC5QCYV7RVivznRykhbJNBhUiuabaAhT2mbRI2Iw/viewform"
 
       section
         = yield

--- a/app/views/pages/now.html.slim
+++ b/app/views/pages/now.html.slim
@@ -9,6 +9,12 @@ section
           a(href=s.url)= s.name
         .title
           = s.title
+
+    h2 Submit Your Talk
+    p
+      | If you want to speak at this or a future Columbus Ruby Brigade meetup,&nbsp;
+      a href="https://docs.google.com/forms/d/e/1FAIpQLSfVTxPvX6kC5QCYV7RVivznRykhbJNBhUiuabaAhT2mbRI2Iw/viewform"
+        | submit your talk details here.
   #location
     #map
       a(href="https://www.google.com/maps/place/500,+2+Miranova+Pl,+Columbus,+OH+43215/@39.9545959,-83.0081614,17z/data=!3m1!4b1!4m2!3m1!1s0x88388f478a5f25b3:0x1d1193f8f62da2d4")
@@ -23,7 +29,7 @@ section
       p
         | Free parking is available in the Miranova parking garage, located off Mound Street.
         |  After 5pm, key cards are not required and parking is open in
-        | all spots if it doesn't say "24 Hour Reserve." ("Reserved" is ok). Take a ticket when you enter the garage, bring it with you, 
+        | all spots if it doesn't say "24 Hour Reserve." ("Reserved" is ok). Take a ticket when you enter the garage, bring it with you,
         |and we will put stickers on your ticket to get you out for free.
         br
         | Take the elevator to 11th floor.
@@ -97,4 +103,3 @@ section
           = s.title
         .bio
           = s.bio
-


### PR DESCRIPTION
Currently the talk submission process is "ping someone you know and ask," which doesn't scale super well and also requires more effort than is necessary.
 
SO! Let's add a link to a form where folks can submit their talk ideas!

## Where these go

As is current practice, the Board of Directors vets and schedules talk submissions. Currently interested speakers email/DM/carrier pigeon a board member they know directly. This form makes the process of submitting to the board that much simpler, and will hopefully reduce friction for new speaker submissions.

## Long-Term

Using a Google form is fine for now, but eventually we'll want the submission process built into the application. We don't have a specific milestone for when that will become necessary, but PRs are always welcome for folks who want to give it a crack.

If you're interested in helping with this, hit us up in [our slack](https://columbuxrb.slack.com). If you need an invite [you can get yourself one here](https://crb-slack-invite.herokuapp.com/).

## TODO

* [ ] Update the form to not hardcode a bunch of meeting dates.