### PR TITLE
Show month/year for admin speaker list heading.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,6 +11,10 @@ module ApplicationHelper
     end
   end
 
+  def month_year(date)
+    date.strftime('%B %Y')
+  end
+
   def twitter_handle(handle)
     if handle.present?
       "https://twitter.com/#{handle}"

--- a/app/views/admin/speakers/index.html.slim
+++ b/app/views/admin/speakers/index.html.slim
@@ -2,7 +2,8 @@ p.mb-3.mt-4
   = link_to 'Add Speaker', new_admin_speaker_path, class: 'bg-blue hover:bg-blue-dark text-white font-bold py-2 px-4 rounded no-underline my-4'
 
 - @speakers.each do |meeting, speakers|
-    h2= formatted_date meeting.time
+    h2 alt=formatted_date(meeting.time)
+      = month_year(meeting.time)
     - speakers.each do |speaker|
       .flex
         div class="w-1/3"


### PR DESCRIPTION
Looks like this now: 

![Screenshot from 2019-08-06 13-32-02](https://user-images.githubusercontent.com/6690/62562209-b8dd9500-b84e-11e9-82ac-4d72b4bf6881.png)

Which isn't too bad, but all the detail in the heading is unnecessary. If it looks like this, it's easier to scan quickly:

![Screenshot from 2019-08-06 13-31-23](https://user-images.githubusercontent.com/6690/62562293-d3b00980-b84e-11e9-8b6b-d4cb28280301.png)
