### PR TITLE
Add Data-Axle to list.

### DIFF
--- a/public/companies.yml
+++ b/public/companies.yml
@@ -88,3 +88,10 @@
   location: Columbus
   team_size: Small
   other_tech: Postgres, Twilio, Heroku, AWS, Stimulus, React
+  
+- name: Data-Axle
+  url: https://www.data-axle.com
+  market: Data and Marketing
+  location: Remote
+  team_size: Small
+  other_tech: Elasticsearch, Postgres, AWS, Javascript


### PR DESCRIPTION
Data-Axle is hiring developers. One current and one former Columbus
developer are currently on the team. The team is mostly based in Seattle
but is remote friendly. Data-Axle is part of https://www.infogroup.com/

Reach out to austen@data-axle.com if interested.