### PR TITLE
Fix meetup.com link

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -36,7 +36,7 @@ html
 
       section
         #links
-          = link_to "Meetup.com", "http://www.meetup.com/meetup-group-wEkWWOXK/"
+          = link_to "Meetup.com", "https://www.meetup.com/columbusrb/"
           = link_to "Slack", "https://join.slack.com/t/columbusrb/shared_invite/zt-1uq5pecs5-FyMW8vG_ZpdLzjhytosHXw"
           = link_to "GitHub", "https://github.com/columbusrb"
           = link_to "Mailing List", "http://eepurl.com/cVggdb"


### PR DESCRIPTION
The current link is 404ing.